### PR TITLE
Security vulnerabilities fix and update spring version to 5.2.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
         <guava.version>27.0.1-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jacoco.version>0.7.6.201602180812</jacoco.version>
-        <joda-time.version>2.7</joda-time.version>
+        <joda-time.version>2.10.6</joda-time.version>
         <joda-convert.version>1.8.1</joda-convert.version>
         <jackson.version>2.10.3</jackson.version>
         <junit.version>4.12</junit.version>
         <pmd.version>3.6</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.12</junit.version>
-        <spring.version>5.1.15.RELEASE</spring.version>
+        <spring.version>5.2.7.RELEASE</spring.version>
         <spring.cloud.version>2.2.1.RELEASE</spring.cloud.version>
         <querydsl.version>4.2.2</querydsl.version>
         <mongo>3.9.1</mongo>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.4.RELEASE</version>
+            <version>2.2.8.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.7.Final</version>
+            <version>6.1.5.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.7</version>
+            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>de.bwaldvogel</groupId>
             <artifactId>mongo-java-server</artifactId>
-            <version>1.11.1</version>
+            <version>1.32.0</version>
         </dependency>
     </dependencies>
 
@@ -670,19 +670,19 @@
                                 <configuration>
                                     <tasks>
                                         <exec executable="git">
-                                            <arg line="clone -b gh-pages --single-branch ${site.publish.url} ${site.publish.checkout.directory}" />
+                                            <arg line="clone -b gh-pages --single-branch ${site.publish.url} ${site.publish.checkout.directory}"/>
                                         </exec>
 
                                         <exec executable="git" dir="site-content">
-                                            <arg line="fetch origin gh-pages" />
+                                            <arg line="fetch origin gh-pages"/>
                                         </exec>
 
                                         <exec executable="git" dir="site-content">
-                                            <arg line="reset --hard origin/gh-pages" />
+                                            <arg line="reset --hard origin/gh-pages"/>
                                         </exec>
 
                                         <pathconvert pathsep=" " property="dirs">
-                                            <dirset dir="${site.publish.checkout.directory}" includes="*" />
+                                            <dirset dir="${site.publish.checkout.directory}" includes="*"/>
                                         </pathconvert>
                                     </tasks>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.capitalone.dashboard</groupId>
             <artifactId>hygieia-query</artifactId>
-            <version>1.0.0</version>
+            <version>${hygieia.query.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <repository.name>hygieia-common</repository.name>
-        <hygieia.query.version>1.0.0</hygieia.query.version>
+        <hygieia.query.version>1.0.1</hygieia.query.version>
         <guava.version>27.0.1-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jacoco.version>0.7.6.201602180812</jacoco.version>

--- a/src/test/java/com/capitalone/dashboard/repository/DashboardCreateTests.java
+++ b/src/test/java/com/capitalone/dashboard/repository/DashboardCreateTests.java
@@ -73,7 +73,7 @@ public class DashboardCreateTests extends MongoServerBaseRepositoryTest {
 
 
 
-        for (Dashboard d : dashboardRepository.findAll(new Sort(Sort.Direction.ASC, "title"))) {
+        for (Dashboard d : dashboardRepository.findAll(Sort.by(Sort.Direction.ASC, "title"))) {
             System.out.println(d.getTitle());
             assertEquals(d.getTitle(), "Jays's Dashboard");
         }


### PR DESCRIPTION
- Upgrade spring version from 5.1.15.RELEASE to 5.2.7.RELEASE
- Upgrade com.google.code.gson:gson from 2.7 to 2.8.6
- Upgrade joda-time:joda-time from 2.7 to 2.10.6
- Upgrade org.springframework.data:spring-data-mongodb from 2.1.4.RELEASE to 2.2.8.RELEASE
- Upgrade de.bwaldvogel:mongo-java-server from 1.11.1 to 1.32.0
- Upgrade org.hibernate:hibernate-validator from 6.0.7.Final to 6.1.5.Final